### PR TITLE
Properly fix the disabling of Buster style wireless/wired network in piaware-support

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -6,5 +6,8 @@ FILES=fa_config_generator.tcl
 
 all: pkgIndex.tcl
 
+install:
+	$(MAKE) -C helpers install
+
 pkgIndex.tcl: $(FILES)
 	echo 'pkg_mkIndex .' | $(TCLSH)

--- a/package/helpers/Makefile
+++ b/package/helpers/Makefile
@@ -1,0 +1,10 @@
+PREFIX=/usr
+LIB=$(PREFIX)/lib/piaware-support/helpers
+FILES=piaware-restart-network
+
+all:
+
+install: $(FILES)
+	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(LIB)
+	install -m 0755 $(FILES) $(DESTDIR)$(PREFIX)/bin
+	install $(FILES) $(DESTDIR)$(LIB)

--- a/package/helpers/piaware-restart-network
+++ b/package/helpers/piaware-restart-network
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Tries to reconfigure and restart networking.
+
+status=0
+
+/bin/systemctl --quiet stop networking
+
+/bin/systemctl --quiet restart set-rfkill || status=1
+/bin/systemctl --quiet restart generate-network-config || status=1
+/bin/systemctl --quiet daemon-reload || status=1
+/sbin/dhcpcd --quiet --release || status=1
+/bin/systemctl --quiet restart dhcpcd || status=1
+/bin/systemctl --quiet restart rsyslog || status=1
+
+/bin/systemctl --quiet start networking || status=1
+
+exit $status

--- a/scripts/generate-network-config
+++ b/scripts/generate-network-config
@@ -168,13 +168,23 @@ slaac private
 
 		lappend dhcpcd ""
 
-		if {![$config get wireless-network]} {
-			set wlan [::fa_sysinfo::wireless_interface]
-			lappend dhcpcd "denyinterfaces $wlan"
-		}
+		set wireless_enabled [$config get wireless-network]
+		set wired_enabled [$config get wired-network]
 
-		if {![$config get wired-network]} {
-			lappend dhcpcd "denyinterfaces eth0"
+		# generate denyinterfaces line if needed
+		if {!$wireless_enabled || !$wired_enabled} {
+			set denyOpt "denyinterfaces"
+
+			if {!$wireless_enabled} {
+				set wlan [::fa_sysinfo::wireless_interface]
+				lappend denyOpt $wlan
+			}
+
+			if {!$wired_enabled} {
+				lappend denyOpt eth0
+			}
+
+			lappend dhcpcd $denyOpt
 		}
 
 		::fa_config_generator::generate_file "/etc/dhcpcd.conf" $dhcpcd

--- a/scripts/generate-network-config
+++ b/scripts/generate-network-config
@@ -123,12 +123,27 @@ namespace eval ::buster {
 		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
 	}
 
-	# Adds "nohook wpa_supplicant" option to dhcpcd.conf to disable wpa_supplicant for particular interface
-	proc disable_wpa_supplicant {config interface} {
-		::fa_config_generator::logger "Disabling wpa_supplicant for $interface..."
+	# Disables the given network interface in dhcpcd.conf
+	proc disable_interface {config interface} {
+		::fa_config_generator::logger "Disabling $interface interface in dhcpcd.conf..."
 		set dhcpcd [list]
-		lappend dhcpcd "interface $interface"
-		lappend dhcpcd "nohook wpa_supplicant"
+
+		switch -glob -nocase $interface {
+			eth0 {
+				lappend dhcpcd "denyinterfaces $interface"
+			}
+
+			wlan* {
+				lappend dhcpcd "interface $interface"
+				lappend dhcpcd "denyinterfaces $interface"
+				lappend dhcpcd "nohook wpa_supplicant"
+			}
+
+			default {
+
+			}
+		}
+
 		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
 	}
 
@@ -179,13 +194,13 @@ slaac private
 
 		if {![$config get wireless-network]} {
 			set wlan [::fa_sysinfo::wireless_interface]
-			disable_wpa_supplicant $config $wlan
+			disable_interface $config $wlan
 		} else {
 			configure_wireless $config
 		}
 
 		if {![$config get wired-network]} {
-			disable_wpa_supplicant $config eth0
+			disable_interface $config eth0
 		} else {
 			configure_wired $config
 		}

--- a/scripts/generate-network-config
+++ b/scripts/generate-network-config
@@ -123,30 +123,6 @@ namespace eval ::buster {
 		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
 	}
 
-	# Disables the given network interface in dhcpcd.conf
-	proc disable_interface {config interface} {
-		::fa_config_generator::logger "Disabling $interface interface in dhcpcd.conf..."
-		set dhcpcd [list]
-
-		switch -glob -nocase $interface {
-			eth0 {
-				lappend dhcpcd "denyinterfaces $interface"
-			}
-
-			wlan* {
-				lappend dhcpcd "interface $interface"
-				lappend dhcpcd "denyinterfaces $interface"
-				lappend dhcpcd "nohook wpa_supplicant"
-			}
-
-			default {
-
-			}
-		}
-
-		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
-	}
-
 	proc generate_network_config {config} {
 		# /etc/dhcpcd.conf base config
 
@@ -190,20 +166,21 @@ slaac private
 			lappend dhcpcd "clientid"
 		}
 
-		::fa_config_generator::generate_file "/etc/dhcpcd.conf" $dhcpcd
+		lappend dhcpcd ""
 
 		if {![$config get wireless-network]} {
 			set wlan [::fa_sysinfo::wireless_interface]
-			disable_interface $config $wlan
-		} else {
-			configure_wireless $config
+			lappend dhcpcd "denyinterfaces $wlan"
 		}
 
 		if {![$config get wired-network]} {
-			disable_interface $config eth0
-		} else {
-			configure_wired $config
+			lappend dhcpcd "denyinterfaces eth0"
 		}
+
+		::fa_config_generator::generate_file "/etc/dhcpcd.conf" $dhcpcd
+
+		configure_wireless $config
+		configure_wired $config
 	}
 } ;# buster
 

--- a/scripts/generate-network-config
+++ b/scripts/generate-network-config
@@ -123,6 +123,15 @@ namespace eval ::buster {
 		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
 	}
 
+	# Adds "nohook wpa_supplicant" option to dhcpcd.conf to disable wpa_supplicant for particular interface
+	proc disable_wpa_supplicant {config interface} {
+		::fa_config_generator::logger "Disabling wpa_supplicant for $interface..."
+		set dhcpcd [list]
+		lappend dhcpcd "interface $interface"
+		lappend dhcpcd "nohook wpa_supplicant"
+		::fa_config_generator::generate_file_part "/etc/dhcpcd.conf" $dhcpcd
+	}
+
 	proc generate_network_config {config} {
 		# /etc/dhcpcd.conf base config
 
@@ -168,8 +177,18 @@ slaac private
 
 		::fa_config_generator::generate_file "/etc/dhcpcd.conf" $dhcpcd
 
-		configure_wireless $config
-		configure_wired $config
+		if {![$config get wireless-network]} {
+			set wlan [::fa_sysinfo::wireless_interface]
+			disable_wpa_supplicant $config $wlan
+		} else {
+			configure_wireless $config
+		}
+
+		if {![$config get wired-network]} {
+			disable_wpa_supplicant $config eth0
+		} else {
+			configure_wired $config
+		}
 	}
 } ;# buster
 


### PR DESCRIPTION
This change adds the "nohook wpa_supplicant" option to the interface (wlan/eth0) in dhcpcd.conf to properly disable the interface. 

This should be more of a proper fix for the workaround I put in flightfeeder-support where I delete wpa_supplicant.conf before calling generate-network-config.