### PR TITLE
Update piaware-network-restart-bookworm script 

### DIFF
--- a/debian-bookworm/piaware-support.install
+++ b/debian-bookworm/piaware-support.install
@@ -17,5 +17,5 @@ etc/kernel/postinst.d/rpi-bootconfig
 etc/kernel/postinst.d/zz-update-bootconfig
 etc/kernel/postrm.d/rpi-bootconfig
 etc/kernel/postrm.d/zz-update-bootconfig
-package/helpers/piaware-restart-network-bookworm usr/bin/
+package/helpers/piaware-restart-network-bookworm usr/bin/piaware-restart-network
 package/helpers/piaware-restart-receiver usr/bin/

--- a/debian-bullseye/piaware-image-config.txt
+++ b/debian-bullseye/piaware-image-config.txt
@@ -3,3 +3,4 @@
 
 manage-config yes
 image-type piaware
+network-config-style buster

--- a/debian-buster/piaware-image-config.txt
+++ b/debian-buster/piaware-image-config.txt
@@ -3,3 +3,4 @@
 
 manage-config yes
 image-type piaware
+network-config-style buster

--- a/package/helpers/piaware-restart-network-bookworm
+++ b/package/helpers/piaware-restart-network-bookworm
@@ -8,7 +8,7 @@
 
 echo "Generating network configuration..."
 
-/bin/systemctl --quiet restart gednerate-network-config || exit 1
+/bin/systemctl --quiet restart generate-network-config || exit 1
 
 echo "Applying network configuration changes..."
 

--- a/package/helpers/piaware-restart-network-bookworm
+++ b/package/helpers/piaware-restart-network-bookworm
@@ -1,20 +1,17 @@
 #!/bin/sh
 
-# Tries to reconfigure and restart networking.
+#
+# Executable script to apply network piaware-config changes without rebooting
+#
+# Compatible with a Bookworm PiAware SD images that use NetworkManager
+#
 
-status=0
+echo "Generating network configuration..."
 
-echo "Stopping network..."
+/bin/systemctl --quiet restart gednerate-network-config || exit 1
 
-nmcli con down wireless
+echo "Applying network configuration changes..."
 
-/bin/systemctl --quiet restart NetworkManager || status=1
+/bin/nmcli connection reload || exit 1
 
-sleep 10s
-
-nmcli con up wireless
-
-
-echo "Done. Wait a moment for networking changes to take effect"
-
-exit $status
+echo "Done. Wait a moment for networking changes to take effect."


### PR DESCRIPTION
- Updates the executable script used to apply network changes without having to reboot
- Create distribution specific piaware-image-config.txt for bullseye and buster and remove `network-config-style buster` from the top level one as its not longer needed 