### PR TITLE
Fix piaware-config parsing for apostrophes and NetworkManager

### DIFF
--- a/debian-bookworm/networking/generate_network_config_bookworm.py
+++ b/debian-bookworm/networking/generate_network_config_bookworm.py
@@ -110,11 +110,23 @@ def get_wired_conn_file(config: ConfigGroup):
 
     return '\n'.join(file)
 
+def escape_backslashes_for_network_manager(value: str) -> str:
+    escaped_str = ""
+    for v in value:
+        if v == "\\":
+            escaped_str += "\\\\"
+        else:
+            escaped_str += v
+    return escaped_str
+
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)
     ssid = config.get("wireless-ssid")
     psk = config.get("wireless-password")
     connect = "true" if config.get("wireless-network") else "false"
+
+    ssid = escape_backslashes_for_network_manager(ssid)
+    psk = escape_backslashes_for_network_manager(psk)
 
     file = [
         "[connection]",

--- a/debian-bookworm/networking/generate_network_config_bookworm.py
+++ b/debian-bookworm/networking/generate_network_config_bookworm.py
@@ -111,13 +111,7 @@ def get_wired_conn_file(config: ConfigGroup):
     return '\n'.join(file)
 
 def escape_backslashes_for_network_manager(value: str) -> str:
-    escaped_str = ""
-    for v in value:
-        if v == "\\":
-            escaped_str += "\\\\"
-        else:
-            escaped_str += v
-    return escaped_str
+    return value.replace("\\", "\\\\")
 
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)

--- a/debian-bookworm/networking/test_generate_network_config_bookworm.py
+++ b/debian-bookworm/networking/test_generate_network_config_bookworm.py
@@ -134,6 +134,9 @@ class TestCases(unittest.TestCase):
         with self.assertRaises(ValueError):
             get_prefix("255.1.1.1", None)
 
+    def test_escape_backslashes_for_network_manager(self):
+        assert escape_backslashes_for_network_manager("value with \\") == "value with \\\\"
+
     def test_configure_static_network(self):
         address = "192.111.1.42"
         gateway = "192.111.1.33"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 piaware-support (10.2~dev) UNRELEASED; urgency=medium
 
-  * Add additional parsing logic for NetworkManager psk
+  * Add additional parsing logic for NetworkManager psk + ssid
 
  -- Nicholas Wan <nicholas.wan@flightaware.com>  Mon, 28 May 2025 11:05:00 -0500
 

--- a/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
+++ b/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
@@ -303,10 +303,12 @@ class ConfigFile():
         return val
 
     def check_value(self, key: str, value: str) -> None:
-        if (re.search(r'\\ ', value)):
-            print(f"\n\nWARNING: You seem to have an unescaped \\ for key: {key}\n\n")
-        if re.search(r'".*[ a-zA-Z0-9]".*"', value):
-            print(f'\n\nWARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n\n')
+        # Emit warning if there's a backslash in a quoted values
+        if (re.search(r'".*\\.*"', value)):
+            print(f"\nWARNING: Make sure your backslash is escaped or modifying something for key: {key}\n")
+        # Emits warning if there's an unescaped " that's enclosed within quotes
+        if re.search(r'".*[^\\]".*"', value):
+            print(f'\nWARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n')
 
     def parse_line(self, line: str) -> tuple | None:
         if re.search(r"^\s*#.*", line):

--- a/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
+++ b/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
@@ -311,13 +311,14 @@ class ConfigFile():
             print(f'\nWARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n')
 
     def parse_line(self, line: str) -> tuple | None:
+        # Line is empty except for comment
         if re.search(r"^\s*#.*", line):
             return None
-
+        # Line has key but no value. Plus optional comment
         option_line = re.search(r"^\s*([a-zA-Z0-9_-]+)\s*(?:#.*)?$", line)
         if option_line:
             return (option_line.group(1), "")
-
+        # Line has key + value. Plus optional comment.
         option_line = re.search(r"^\s*([a-zA-Z0-9_-]+)\s+(.+)$", line)
         if option_line:
             key = option_line.group(1)

--- a/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
+++ b/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
@@ -6,6 +6,7 @@
 from uuid import UUID, uuid4
 import re
 import os
+import sys
 from ipaddress import IPv4Network, NetmaskValueError
 
 COUNTRY = "country"
@@ -305,10 +306,10 @@ class ConfigFile():
     def check_value(self, key: str, value: str) -> None:
         # Emit warning if there's a backslash in a quoted values
         if (re.search(r'".*\\.*"', value)):
-            print(f"\nWARNING: Make sure your backslash is escaped or modifying something for key: {key}\n")
+            sys.stderr.write(f"WARNING: Make sure your backslash is escaped or modifying something for key: {key}.\n")
         # Emits warning if there's an unescaped " that's enclosed within quotes
         if re.search(r'".*[^\\]".*"', value):
-            print(f'\nWARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n')
+            sys.stderr.write(f'WARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n')
 
     def parse_line(self, line: str) -> tuple | None:
         # Line is empty except for comment

--- a/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
+++ b/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
@@ -160,14 +160,13 @@ class NetmaskProcessor():
         return val
 
 class MetadataSettings():
-    def __init__(self, processor, default: any = None, setting_type: str = None, protect: str = None, sdonly: bool = None, network: str = None, network_manager_value = False, deprecated = False) -> None:
+    def __init__(self, processor, default: any = None, setting_type: str = None, protect: str = None, sdonly: bool = None, network: str = None, deprecated = False) -> None:
         self.default = default
         self.setting_type = setting_type
         self.protect = protect
         self.sdonly = sdonly
         self.network = network
         self.deprecated = deprecated
-        self.network_manager_value = network_manager_value
         self.processor = processor
 
 class Metadata():
@@ -268,7 +267,7 @@ class ConfigFile():
         self._filename = filename
         self.values = {}
     
-    def process_quotes(self, line: str, processing_for_nm: bool = False) -> str:
+    def process_quotes(self, line: str) -> str:
         if len(line) == 0:
             return line
 
@@ -287,9 +286,6 @@ class ConfigFile():
         for i in range(1, len(line)):
             char = line[i]
             if esc:
-                # NetworkManager specifically needs \ to be escaped
-                if processing_for_nm and char == "\\":
-                    val += "\\"
                 val += char
                 esc = False
                 continue
@@ -314,9 +310,7 @@ class ConfigFile():
 
         option_line = re.search(r"^\s*([a-zA-Z0-9_-]+)\s+(.+)$", line)
         if option_line:
-            key = option_line.group(1)
-            needs_network_manager_specific_parsing = self._metadata.get_setting(key).network_manager_value
-            return (key, self.process_quotes(option_line.group(2), processing_for_nm=needs_network_manager_specific_parsing))
+            return (option_line.group(1), self.process_quotes(option_line.group(2)))
 
         return None
 

--- a/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
+++ b/flightaware_piaware_config/src/flightaware_piaware_config/piaware_config.py
@@ -268,11 +268,13 @@ class ConfigFile():
         self.values = {}
     
     def process_quotes(self, line: str) -> str:
+        line = line.strip()
+
         if len(line) == 0:
             return line
 
-        line = line.strip()
-        if line[0] != "\"" and line[0] != "'":
+
+        if line[0] != '"' and line[0] != "'":
             comment_index = line.find("#")
             if comment_index == -1:
                 return line
@@ -281,7 +283,7 @@ class ConfigFile():
 
         val = ""
         esc = False
-        terminating_char = "\"" if line[0] == "\"" else "'"
+        terminating_char = line[0]
 
         for i in range(1, len(line)):
             char = line[i]
@@ -300,7 +302,13 @@ class ConfigFile():
 
         return val
 
-    def parse_line(self, line) -> tuple | None:
+    def check_value(self, key: str, value: str) -> None:
+        if (re.search(r'\\ ', value)):
+            print(f"\n\nWARNING: You seem to have an unescaped \\ for key: {key}\n\n")
+        if re.search(r'".*[ a-zA-Z0-9]".*"', value):
+            print(f'\n\nWARNING: Do you have an unescaped " that\'s been quoted for key: {key}?\n\n')
+
+    def parse_line(self, line: str) -> tuple | None:
         if re.search(r"^\s*#.*", line):
             return None
 
@@ -310,7 +318,10 @@ class ConfigFile():
 
         option_line = re.search(r"^\s*([a-zA-Z0-9_-]+)\s+(.+)$", line)
         if option_line:
-            return (option_line.group(1), self.process_quotes(option_line.group(2)))
+            key = option_line.group(1)
+            value = option_line.group(2)
+            self.check_value(key, value)
+            return (key, self.process_quotes(value))
 
         return None
 

--- a/flightaware_piaware_config/tests/test_piaware_config.py
+++ b/flightaware_piaware_config/tests/test_piaware_config.py
@@ -198,36 +198,38 @@ class TestConfigFile(unittest.TestCase):
 
         ### Escape special characters in quotes/ticks
         # "commented\s\1"
-        assert testc.process_quotes("\"commented\\s\\1\"") == "commenteds1"
+        assert testc.process_quotes(r'"commented\s\1"') == "commenteds1"
 
-        # "back \ slash" -> "back \\ slash"
-        assert testc.process_quotes("\"back \\\\ slash\"") == "back \\ slash"
+        # "back \ slash"
+        assert testc.process_quotes(r'"back \\ slash"') == r"back \ slash"
 
-        # "some " thing" -> "some \" thing"
-        assert testc.process_quotes("\"some \\\" thing\"") == "some \" thing"
+        # "some " thing"
+        assert testc.process_quotes(r'"some \" thing"') == r'some " thing'
 
         # "some \" thing"
-        assert testc.process_quotes("\"some \\\" thing\"") == "some \" thing"
+        assert testc.process_quotes(r'"some \\\" thing"') == r'some \" thing'
 
-        # "some \' thing"
-        assert testc.process_quotes("\"some \\' thing\"") == "some ' thing"
-
+        # "some ' thing"
+        assert testc.process_quotes("\"some \' thing\"") == "some ' thing"
 
         # 'commented\s\1'
-        assert testc.process_quotes("'commented\\s\\1'") == "commenteds1"
+        assert testc.process_quotes(r"'commented\s\1'") == "commenteds1"
 
         # 'back \ slash'
-        assert testc.process_quotes("'back \\\\ slash'") == "back \\ slash"
+        assert testc.process_quotes(r"'back \\ slash'") == r"back \ slash"
 
         # 'some " thing'
-        assert testc.process_quotes("'some \\\" thing'") == "some \" thing"
+        assert testc.process_quotes(r"'some \" thing'") == r'some " thing'
 
-        # tick' mark -> 'tick\' mark'
-        assert testc.process_quotes("'tick\\\' mark'") == "tick' mark"
+        # tick' mark
+        assert testc.process_quotes(r"'tick\' mark'") == "tick' mark"
 
         # Te!st"\pas\s
-        assert testc.process_quotes("\"Te!st\\\"\\\\pas\\\\s\"") == "Te!st\"\\pas\\s"
+        assert testc.process_quotes(r'"Te!st\"\\pas\\s"') == r'Te!st"\pas\s'
 
+        ### Bad Cases
+        assert testc.process_quotes(r'"input with "unescaped quote"') == "input with "
+        assert testc.process_quotes(r'"input with \ backslash"') == "input with  backslash"
 
     def test_parse_line(self):
         testm = Metadata()
@@ -262,6 +264,18 @@ class TestConfigFile(unittest.TestCase):
         key, val = testc.parse_line("   option \"   yes   \" # comment")
         assert key == "option"
         assert val == "   yes   "
+
+        key, val = testc.parse_line(r'   option " \  yes   " # comment')
+        assert key == "option"
+        assert val == "   yes   "
+
+        key, val = testc.parse_line(r'   option \  yes  # comment')
+        assert key == "option"
+        assert val == r"\  yes"
+
+        key, val = testc.parse_line(r'   option \ " y"es " # comment')
+        assert key == "option"
+        assert val == r'\ " y"es "'
 
     def test_parse_config_from_list(self):
         testm = Metadata()

--- a/flightaware_piaware_config/tests/test_piaware_config.py
+++ b/flightaware_piaware_config/tests/test_piaware_config.py
@@ -13,7 +13,6 @@ class TestMetadataSettings(unittest.TestCase):
         assert testm.protect is None
         assert testm.sdonly is None
         assert testm.network is None
-        assert testm.network_manager_value is False
         assert testm.deprecated is False
 
 class TestMetadata(unittest.TestCase):
@@ -217,7 +216,7 @@ class TestConfigFile(unittest.TestCase):
         # 'commented\s\1'
         assert testc.process_quotes("'commented\\s\\1'") == "commenteds1"
 
-        # 'back \ slash' -> 'back \\ slash'
+        # 'back \ slash'
         assert testc.process_quotes("'back \\\\ slash'") == "back \\ slash"
 
         # 'some " thing'
@@ -226,15 +225,9 @@ class TestConfigFile(unittest.TestCase):
         # tick' mark -> 'tick\' mark'
         assert testc.process_quotes("'tick\\\' mark'") == "tick' mark"
 
-        # Te!st"\pas\s -> "Te!st\"\\pas\\s"
+        # Te!st"\pas\s
         assert testc.process_quotes("\"Te!st\\\"\\\\pas\\\\s\"") == "Te!st\"\\pas\\s"
 
-        assert testc.process_quotes("\"Te!st\\\"\\\\pas\\\\s\"", processing_for_nm=True) == "Te!st\"\\\\pas\\\\s"
-        assert testc.process_quotes("Password's with comma", processing_for_nm=True) == "Password's with comma"
-        assert testc.process_quotes("\"Password's with comma\" # comments", processing_for_nm=True) == "Password's with comma"
-        assert testc.process_quotes("'Something\" with apostrophe' # comments ", processing_for_nm=True) == "Something\" with apostrophe"
-        assert testc.process_quotes("\"   Password's   with      lot's   of spaces   \"", processing_for_nm=True) == "   Password's   with      lot's   of spaces   "
-        assert testc.process_quotes("\"'/()$&@\\\"-[]{}#%^*+\\\\\"", processing_for_nm=True) == "'/()$&@\"-[]{}#%^*+\\\\"
 
     def test_parse_line(self):
         testm = Metadata()

--- a/flightaware_piaware_config/tests/test_piaware_config.py
+++ b/flightaware_piaware_config/tests/test_piaware_config.py
@@ -265,17 +265,19 @@ class TestConfigFile(unittest.TestCase):
         assert key == "option"
         assert val == "   yes   "
 
-        key, val = testc.parse_line(r'   option " \  yes   " # comment')
-        assert key == "option"
-        assert val == "   yes   "
-
         key, val = testc.parse_line(r'   option \  yes  # comment')
         assert key == "option"
         assert val == r"\  yes"
 
-        key, val = testc.parse_line(r'   option \ " y"es " # comment')
+        # Test Cases should print out warnings
+
+        key, val = testc.parse_line(r'   option   " \  yes   " # comment')
         assert key == "option"
-        assert val == r'\ " y"es "'
+        assert val == "   yes   "
+
+        key, val = testc.parse_line(r'   option   \  " y"es " # comment')
+        assert key == "option"
+        assert val == r'\  " y"es "'
 
     def test_parse_config_from_list(self):
         testm = Metadata()


### PR DESCRIPTION
The parsing logic in piaware-config misses some edges cases (some are specifically when parsing network SSIDs and passkeys).

Ex.
" Passwordwith3spaces". We should not strip the spaces in the quotes. The current logic will strip these spaces.
"Password I've put tick mark" will truncate off and result in "Password I". This shouldn't happen.
NetworkManager needs \ to be escaped in passkeys. So a password like "back\slash" needs to be "back\slash".