### PR TITLE
Handle UTF-8-encoded SSIDs when generating NetworkManager connections

### DIFF
--- a/networking/generate_network_config.py
+++ b/networking/generate_network_config.py
@@ -6,6 +6,7 @@ import subprocess
 import os
 import stat
 import ipaddress
+import re
 
 SYS_CON_DIR = "/etc/NetworkManager/system-connections"
 
@@ -110,18 +111,19 @@ def get_wired_conn_file(config: ConfigGroup):
 
     return '\n'.join(file)
 
-def escape_backslashes_for_network_manager(value: str) -> str:
-    return value.replace("\\", "\\\\")
 
 def ssid_to_byte_format(ssid: str) -> str:
-    """Convert SSID to semicolon-separated byte values if it contains non-ASCII characters."""
-    try:
-        ssid.encode('ascii')
-        return ssid  # All ASCII, return as-is
-    except UnicodeEncodeError:
-        # Contains non-ASCII characters, convert to byte format
+    """Convert SSID to semicolon-separated byte values if it contains non-ASCII characters
+    or escaped Unicode sequences like \\u2019.
+    """
+    # First check for escaped Unicode sequences 
+    if bool(re.search(r'[^\u0000-\u007F]', ssid)):
         return ";".join(str(byte) for byte in ssid.encode('utf-8')) + ";"
-
+    
+    # Then check for actual non-ASCII Unicode characters
+    else:
+        return ssid  
+    
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)
     ssid = config.get("wireless-ssid")
@@ -129,8 +131,6 @@ def get_wireless_conn_file(config: ConfigGroup):
     connect = "true" if config.get("wireless-network") else "false"
 
     ssid = ssid_to_byte_format(ssid)
-    ssid = escape_backslashes_for_network_manager(ssid)
-    psk = escape_backslashes_for_network_manager(psk)
 
     file = [
         "[connection]",

--- a/networking/generate_network_config.py
+++ b/networking/generate_network_config.py
@@ -120,7 +120,7 @@ def ssid_to_byte_format(ssid: str) -> str:
         return ssid  # All ASCII, return as-is
     except UnicodeEncodeError:
         # Contains non-ASCII characters, convert to byte format
-        return ";".join(str(byte) for byte in ssid.encode('utf-8'))
+        return ";".join(str(byte) for byte in ssid.encode('utf-8')) + ";"
 
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)

--- a/networking/generate_network_config.py
+++ b/networking/generate_network_config.py
@@ -113,12 +113,22 @@ def get_wired_conn_file(config: ConfigGroup):
 def escape_backslashes_for_network_manager(value: str) -> str:
     return value.replace("\\", "\\\\")
 
+def ssid_to_byte_format(ssid: str) -> str:
+    """Convert SSID to semicolon-separated byte values if it contains non-ASCII characters."""
+    try:
+        ssid.encode('ascii')
+        return ssid  # All ASCII, return as-is
+    except UnicodeEncodeError:
+        # Contains non-ASCII characters, convert to byte format
+        return ";".join(str(byte) for byte in ssid.encode('utf-8'))
+
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)
     ssid = config.get("wireless-ssid")
     psk = config.get("wireless-password")
     connect = "true" if config.get("wireless-network") else "false"
 
+    ssid = ssid_to_byte_format(ssid)
     ssid = escape_backslashes_for_network_manager(ssid)
     psk = escape_backslashes_for_network_manager(psk)
 

--- a/networking/generate_network_config.py
+++ b/networking/generate_network_config.py
@@ -7,6 +7,7 @@ import os
 import stat
 import ipaddress
 import re
+import codecs
 
 SYS_CON_DIR = "/etc/NetworkManager/system-connections"
 
@@ -116,13 +117,15 @@ def ssid_to_byte_format(ssid: str) -> str:
     """Convert SSID to semicolon-separated byte values if it contains non-ASCII characters
     or escaped Unicode sequences like \\u2019.
     """
-    # First check for escaped Unicode sequences 
-    if bool(re.search(r'[^\u0000-\u007F]', ssid)):
-        return ";".join(str(byte) for byte in ssid.encode('utf-8')) + ";"
-    
-    # Then check for actual non-ASCII Unicode characters
+    try:
+        decoded_ssid = codecs.decode(ssid, 'unicode_escape')
+    except Exception:
+        decoded_ssid = ssid
+   
+    if bool(re.search(r'[^\x00-\x7F]', decoded_ssid)):
+        return ";".join(str(byte) for byte in decoded_ssid.encode('utf-8')) + ";"
     else:
-        return ssid  
+        return ssid
     
 def get_wireless_conn_file(config: ConfigGroup):
     uuid = UUID("acc6cf97-9575-4f41-ad85-65af044288df", version=4)

--- a/networking/test_generate_network_config.py
+++ b/networking/test_generate_network_config.py
@@ -137,6 +137,18 @@ class TestCases(unittest.TestCase):
     def test_escape_backslashes_for_network_manager(self):
         assert escape_backslashes_for_network_manager("value with \\") == "value with \\\\"
 
+    def test_ssid_to_byte_format(self):
+        # ASCII SSID should remain unchanged
+        assert ssid_to_byte_format("MyNetwork") == "MyNetwork"
+        assert ssid_to_byte_format("jukka") == "jukka"
+        
+        # SSID with Unicode characters should be converted to byte format
+        # iPhone-Pro's with U+2019 (RIGHT SINGLE QUOTATION MARK)
+        assert ssid_to_byte_format("iPhone-Pro\u2019s") == "105;80;104;111;110;101;45;80;114;111;226;128;153;115"
+        
+        # SSID with accented character
+        assert ssid_to_byte_format("Test\u00e9") == "84;101;115;116;195;169"
+
     def test_configure_static_network(self):
         address = "192.111.1.42"
         gateway = "192.111.1.33"

--- a/networking/test_generate_network_config.py
+++ b/networking/test_generate_network_config.py
@@ -134,8 +134,6 @@ class TestCases(unittest.TestCase):
         with self.assertRaises(ValueError):
             get_prefix("255.1.1.1", None)
 
-    def test_escape_backslashes_for_network_manager(self):
-        assert escape_backslashes_for_network_manager("value with \\") == "value with \\\\"
 
     def test_ssid_to_byte_format(self):
         # ASCII SSID should remain unchanged

--- a/networking/test_generate_network_config.py
+++ b/networking/test_generate_network_config.py
@@ -144,10 +144,10 @@ class TestCases(unittest.TestCase):
         
         # SSID with Unicode characters should be converted to byte format
         # iPhone-Pro's with U+2019 (RIGHT SINGLE QUOTATION MARK)
-        assert ssid_to_byte_format("iPhone-Pro\u2019s") == "105;80;104;111;110;101;45;80;114;111;226;128;153;115"
+        assert ssid_to_byte_format("iPhone-Pro\u2019s") == "105;80;104;111;110;101;45;80;114;111;226;128;153;115;"
         
         # SSID with accented character
-        assert ssid_to_byte_format("Test\u00e9") == "84;101;115;116;195;169"
+        assert ssid_to_byte_format("Test\u00e9") == "84;101;115;116;195;169;"
 
     def test_configure_static_network(self):
         address = "192.111.1.42"


### PR DESCRIPTION
Context:
PiAware-Configurator works with PiAware-BLE to send WiFi SSID captured from "sudo iwlist wlan0 scan" to Web or iOS app and take the password from Web and iOS app and write the SSID and Password to piaware-config.txt. 
The piaware-config.txt file will be used later to generate wireless Network Manager file in PiAware-Support for WiFi access.
WiFi hotspot usually contains only ASCII characters, in rare condition like connecting PiAware to iPhone hotspot of which SSID contains a curly apostrophe following iPhone’s naming scheme XXX’s iPhone. These are legal SSID. However it created a parse challenge which lead to incorrect SSID display and connection failure. 

The proposed fix is converting “iPhone-Pro\u2019s” in the piaware-config.txt to "105;80;104;111;110;101;45;80;114;111;226;128;153;115;”, which the form used in official Debian Network Manager’s connection files for SSID with characters beyond ASCII characters.

Using regex to determine if store the SSID in ASCII or bytes form.